### PR TITLE
Added terraform and terragrunt; changed wget to curl

### DIFF
--- a/Formula/terraform.rb
+++ b/Formula/terraform.rb
@@ -1,0 +1,87 @@
+require "language/go"
+
+class Terraform < Formula
+  desc "Tool to build, change, and version infrastructure"
+  homepage "https://www.terraform.io/"
+  url "https://github.com/hashicorp/terraform/archive/v0.11.7.tar.gz"
+  sha256 "f9a2730dcd68dad754cf0efa017d51929a7f333a89d07ddff3c6ff7b2d1e8be3"
+  head "https://github.com/hashicorp/terraform.git"
+
+  bottle do
+    cellar :any_skip_relocation
+    sha256 "7bce9a18c6b533bce2794ebe0876387cc1639bc4689ee5d1ec9ff38f556e0e39" => :high_sierra
+    sha256 "675d1edc6917527a0724b84ac214d7ce0b95864a2680dd404843492c1803b81c" => :sierra
+    sha256 "db14ad02da3e44831145641e57500c6f80b6be056bfb10c05dc402a93e088043" => :el_capitan
+  end
+
+  depends_on "go" => :build
+  depends_on "gox" => :build
+
+  conflicts_with "tfenv", :because => "tfenv symlinks terraform binaries"
+
+  # stringer is a build tool dependency
+  go_resource "golang.org/x/tools" do
+    url "https://go.googlesource.com/tools.git",
+        :branch => "release-branch.go1.10"
+  end
+
+  def install
+    ENV["GOPATH"] = buildpath
+    ENV.prepend_create_path "PATH", buildpath/"bin"
+
+    dir = buildpath/"src/github.com/hashicorp/terraform"
+    dir.install buildpath.children - [buildpath/".brew_home"]
+    Language::Go.stage_deps resources, buildpath/"src"
+
+    cd "src/golang.org/x/tools/cmd/stringer" do
+      system "go", "install"
+    end
+
+    cd dir do
+      # v0.6.12 - source contains tests which fail if these environment variables are set locally.
+      ENV.delete "AWS_ACCESS_KEY"
+      ENV.delete "AWS_SECRET_KEY"
+
+      arch = MacOS.prefer_64_bit? ? "amd64" : "386"
+      ENV["XC_OS"] = "darwin"
+      ENV["XC_ARCH"] = arch
+      system "make", "test", "bin"
+
+      bin.install "pkg/darwin_#{arch}/terraform"
+      prefix.install_metafiles
+    end
+  end
+
+  test do
+    minimal = testpath/"minimal.tf"
+    minimal.write <<~EOS
+      variable "aws_region" {
+          default = "us-west-2"
+      }
+
+      variable "aws_amis" {
+          default = {
+              eu-west-1 = "ami-b1cf19c6"
+              us-east-1 = "ami-de7ab6b6"
+              us-west-1 = "ami-3f75767a"
+              us-west-2 = "ami-21f78e11"
+          }
+      }
+
+      # Specify the provider and access details
+      provider "aws" {
+          access_key = "this_is_a_fake_access"
+          secret_key = "this_is_a_fake_secret"
+          region = "${var.aws_region}"
+      }
+
+      resource "aws_instance" "web" {
+        instance_type = "m1.small"
+        ami = "${lookup(var.aws_amis, var.aws_region)}"
+        count = 4
+      }
+    EOS
+    system "#{bin}/terraform", "init"
+    system "#{bin}/terraform", "graph"
+  end
+end

--- a/Formula/terragrunt.rb
+++ b/Formula/terragrunt.rb
@@ -1,0 +1,31 @@
+class Terragrunt < Formula
+  desc "Thin wrapper for Terraform e.g. for locking state"
+  homepage "https://github.com/gruntwork-io/terragrunt"
+  url "https://github.com/gruntwork-io/terragrunt/archive/v0.14.10.tar.gz"
+  sha256 "088eaeacd965ade353fa98bdb4e7be0348df00f8850b0299756e269b663a739a"
+  head "https://github.com/gruntwork-io/terragrunt.git"
+
+  bottle do
+    cellar :any_skip_relocation
+    sha256 "8c5e34e5f22d9d8561d72bb95ac87545bb24d675ff59fc364f82279d6a954f5c" => :high_sierra
+    sha256 "ad446a9a4c63f5593341c066fb03816c8cf61173e9069c89adb693f36b88da3a" => :sierra
+    sha256 "5c9cd2dd3c5edccda345c6d85b17f67f46fcd2f23613bb384306cbab819f4156" => :el_capitan
+  end
+
+  depends_on "glide" => :build
+  depends_on "go" => :build
+  depends_on "terraform"
+
+  def install
+    ENV["GOPATH"] = buildpath
+    ENV["GLIDE_HOME"] = HOMEBREW_CACHE/"glide_home/#{name}"
+    mkdir_p buildpath/"src/github.com/gruntwork-io/"
+    ln_s buildpath, buildpath/"src/github.com/gruntwork-io/terragrunt"
+    system "glide", "install"
+    system "go", "build", "-o", bin/"terragrunt", "-ldflags", "-X main.VERSION=v#{version}"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/terragrunt --version")
+  end
+end

--- a/get-formula.sh
+++ b/get-formula.sh
@@ -16,5 +16,5 @@ base_dir=$(cd "$(dirname "$0")" && pwd)
 formula_dir=$base_dir/Formula
 
 pushd $formula_dir &>/dev/null
-wget https://raw.githubusercontent.com/Homebrew/homebrew-core/master/Formula/$1.rb
+curl https://raw.githubusercontent.com/Homebrew/homebrew-core/master/Formula/$1.rb -o $1.rb
 popd &>/dev/null


### PR DESCRIPTION
Going to add terraform and terragrunt to the setup script, so I figured I'd follow the same homebrew pattern as the rest of the packages.

Also, `wget` isn't available on Mac OS unless you brew install it, ironically.