### PR TITLE
Added 11.11 TF version

### DIFF
--- a/Formula/terraform@0.11.11.rb
+++ b/Formula/terraform@0.11.11.rb
@@ -1,0 +1,74 @@
+class TerraformAT01111 < Formula
+  desc "Tool to build, change, and version infrastructure"
+  homepage "https://www.terraform.io/"
+  url "https://github.com/hashicorp/terraform/archive/v0.11.11.tar.gz"
+  sha256 "aa60d15b06ac7a925a722a5ad0070bb1aa580f9ed54cfcc08378f84e25526e01"
+  head "https://github.com/hashicorp/terraform.git"
+
+  bottle do
+    cellar :any_skip_relocation
+    sha256 "f5f3096f7493b4ce63bc1750539201e2931c7730b594f49ca3e852d851a3b571" => :mojave
+    sha256 "f450cc1b615d9fb9dcb10cb2e0a6182989e54ff55ddc3e07538a4f0da39e038e" => :high_sierra
+    sha256 "6956acc2bf7916b8b085c2b4542e962e5d8cabc307bcc7d690f4b13c8d483aeb" => :sierra
+  end
+
+  depends_on "go" => :build
+  depends_on "gox" => :build
+
+  conflicts_with "tfenv", :because => "tfenv symlinks terraform binaries"
+
+  def install
+    ENV["GOPATH"] = buildpath
+    ENV.prepend_create_path "PATH", buildpath/"bin"
+
+    dir = buildpath/"src/github.com/hashicorp/terraform"
+    dir.install buildpath.children - [buildpath/".brew_home"]
+
+    cd dir do
+      # v0.6.12 - source contains tests which fail if these environment variables are set locally.
+      ENV.delete "AWS_ACCESS_KEY"
+      ENV.delete "AWS_SECRET_KEY"
+
+      arch = MacOS.prefer_64_bit? ? "amd64" : "386"
+      ENV["XC_OS"] = "darwin"
+      ENV["XC_ARCH"] = arch
+      system "make", "tools", "test", "bin"
+
+      bin.install "pkg/darwin_#{arch}/terraform"
+      prefix.install_metafiles
+    end
+  end
+
+  test do
+    minimal = testpath/"minimal.tf"
+    minimal.write <<~EOS
+      variable "aws_region" {
+          default = "us-west-2"
+      }
+
+      variable "aws_amis" {
+          default = {
+              eu-west-1 = "ami-b1cf19c6"
+              us-east-1 = "ami-de7ab6b6"
+              us-west-1 = "ami-3f75767a"
+              us-west-2 = "ami-21f78e11"
+          }
+      }
+
+      # Specify the provider and access details
+      provider "aws" {
+          access_key = "this_is_a_fake_access"
+          secret_key = "this_is_a_fake_secret"
+          region = "${var.aws_region}"
+      }
+
+      resource "aws_instance" "web" {
+        instance_type = "m1.small"
+        ami = "${lookup(var.aws_amis, var.aws_region)}"
+        count = 4
+      }
+    EOS
+    system "#{bin}/terraform", "init"
+    system "#{bin}/terraform", "graph"
+  end
+end


### PR DESCRIPTION
Ok, this was pretty nifty.  While [homebrew bundle](https://github.com/Homebrew/homebrew-bundle#note) doesn't support versioning, homebrew does support people running their own taps like this one.  The cool part now is that since last year, it supports [versions](https://docs.brew.sh/Versions.html) in taps.  Also, you can use `homebrew extract` to pull the recipe you want if you have access to it:

```
$: brew extract terraform actioniq-oss/taps
==> Writing formula for terraform from revision HEAD to /usr/local/Homebrew/Library/Taps/actioniq-oss/homebrew-taps/Formula/terraform@0.11.11.rb
```

Even cooler, since homebrew is all based on git in the background, the place it just wrote that file is _already_ a git directory linked to this repo:
```
$: cd /usr/local/Homebrew/Library/Taps/actioniq-oss/homebrew-taps
$: git status
On branch master
Your branch is up to date with 'origin/master'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	.DS_Store
	Formula/terraform@0.11.11.rb

nothing added to commit but untracked files present (use "git add" to track)
$: git checkout -b jd/tfversion
$: git add *.rb
$: git commit -m "Added 11.11 TF version"
$: git push origin jd/tfversion
Counting objects: 4, done.
Delta compression using up to 8 threads.
Compressing objects: 100% (4/4), done.
Writing objects: 100% (4/4), 1.49 KiB | 1.49 MiB/s, done.
Total 4 (delta 1), reused 0 (delta 0)
remote: Resolving deltas: 100% (1/1), completed with 1 local object.
remote: 
remote: Create a pull request for 'jd/tfversion' on GitHub by visiting:
remote:      https://github.com/ActionIQ-OSS/homebrew-taps/pull/new/jd/tfversion
remote: 
To https://github.com/ActionIQ-OSS/homebrew-taps
 * [new branch]      jd/tfversion -> jd/tfversion
```
I don't think we need to have versions on all our recipes in the repo, but TF in particular has been troublesome, so I think we'll want all of them with a history.
