### PR TITLE
Added formulas that match the stuff that brew pinned for me

### DIFF
--- a/Formula/kops@1.11.0.rb
+++ b/Formula/kops@1.11.0.rb
@@ -1,0 +1,38 @@
+class KopsAT1110 < Formula
+  desc "Production Grade K8s Installation, Upgrades, and Management"
+  homepage "https://github.com/kubernetes/kops"
+  url "https://github.com/kubernetes/kops/archive/1.11.0.tar.gz"
+  sha256 "1517abdda57a1f6ad1cb6dcab2b2c23ff15618006ed3bd6724096d13e942d8fb"
+  head "https://github.com/kubernetes/kops.git"
+
+  bottle do
+    cellar :any_skip_relocation
+    sha256 "a1349e0849f72dc4a3fdf9908fb9e5c3bac273d36d16a2fe185feedd95abb448" => :mojave
+    sha256 "f846c1106d7bb9b12e9887a3715633158555f1bce6a58ab88f99fb6f2d6f419b" => :high_sierra
+    sha256 "83dd443876381d47f70d5f94c1e928ebce18f0d1a07d8b90331396f4b13778c1" => :sierra
+  end
+
+  depends_on "go" => :build
+  depends_on "kubernetes-cli"
+
+  def install
+    ENV["VERSION"] = version unless build.head?
+    ENV["GOPATH"] = buildpath
+    kopspath = buildpath/"src/k8s.io/kops"
+    kopspath.install Dir["*"]
+    system "make", "-C", kopspath
+    bin.install("bin/kops")
+
+    # Install bash completion
+    output = Utils.popen_read("#{bin}/kops completion bash")
+    (bash_completion/"kops").write output
+
+    # Install zsh completion
+    output = Utils.popen_read("#{bin}/kops completion zsh")
+    (zsh_completion/"_kops").write output
+  end
+
+  test do
+    system "#{bin}/kops", "version"
+  end
+end

--- a/Formula/kubernetes-cli@1.13.2.rb
+++ b/Formula/kubernetes-cli@1.13.2.rb
@@ -1,0 +1,61 @@
+class KubernetesCli < Formula
+  desc "Kubernetes command-line interface"
+  homepage "https://kubernetes.io/"
+  url "https://github.com/kubernetes/kubernetes.git",
+      :tag      => "v1.13.2",
+      :revision => "cff46ab41ff0bb44d8584413b598ad8360ec1def"
+  head "https://github.com/kubernetes/kubernetes.git"
+
+  bottle do
+    cellar :any_skip_relocation
+    sha256 "2e0395d1f60d77cddbc1e17bd06fa8941b753e2ae34076ad822a659dbaba6cf7" => :mojave
+    sha256 "92ed9b714143988d1c1f3a4a11b168c5d236bd00a35f4893c2474c8681e00296" => :high_sierra
+    sha256 "e8e69401eab07e6d19bb1c90c9f4e8d4b1dc061a82c51b8c91853106643b458d" => :sierra
+  end
+
+  depends_on "go" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+    dir = buildpath/"src/k8s.io/kubernetes"
+    dir.install buildpath.children - [buildpath/".brew_home"]
+
+    cd dir do
+      # Race condition still exists in OS X Yosemite
+      # Filed issue: https://github.com/kubernetes/kubernetes/issues/34635
+      ENV.deparallelize { system "make", "generated_files" }
+
+      # Make binary
+      system "make", "kubectl"
+      bin.install "_output/local/bin/darwin/amd64/kubectl"
+
+      # Install bash completion
+      output = Utils.popen_read("#{bin}/kubectl completion bash")
+      (bash_completion/"kubectl").write output
+
+      # Install zsh completion
+      output = Utils.popen_read("#{bin}/kubectl completion zsh")
+      (zsh_completion/"_kubectl").write output
+
+      prefix.install_metafiles
+
+      # Install man pages
+      # Leave this step for the end as this dirties the git tree
+      system "hack/generate-docs.sh"
+      man1.install Dir["docs/man/man1/*.1"]
+    end
+  end
+
+  test do
+    run_output = shell_output("#{bin}/kubectl 2>&1")
+    assert_match "kubectl controls the Kubernetes cluster manager.", run_output
+
+    version_output = shell_output("#{bin}/kubectl version --client 2>&1")
+    assert_match "GitTreeState:\"clean\"", version_output
+    if build.stable?
+      assert_match stable.instance_variable_get(:@resource)
+                         .instance_variable_get(:@specs)[:revision],
+                   version_output
+    end
+  end
+end

--- a/Formula/kubernetes-helm@2.12.2.rb
+++ b/Formula/kubernetes-helm@2.12.2.rb
@@ -1,0 +1,54 @@
+class KubernetesHelm < Formula
+  desc "The Kubernetes package manager"
+  homepage "https://helm.sh/"
+  url "https://github.com/helm/helm.git",
+      :tag      => "v2.12.2",
+      :revision => "7d2b0c73d734f6586ed222a567c5d103fed435be"
+  head "https://github.com/helm/helm.git"
+
+  bottle do
+    cellar :any_skip_relocation
+    sha256 "4158a25a57f57ee7d663b7910ebc1e575437b149c43348d0d78b2dfc16e02df5" => :mojave
+    sha256 "0ee5e8485a1f13631da72cced9cc7804c9882727a3dac67201898a4be8fc7a13" => :high_sierra
+    sha256 "915d6e6642f2078f8a68563d1d94fdc310232ecb43f07d1497c69dba047aefb1" => :sierra
+  end
+
+  depends_on "glide" => :build
+  depends_on "go" => :build
+  depends_on "mercurial" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+    ENV["GLIDE_HOME"] = HOMEBREW_CACHE/"glide_home/#{name}"
+    ENV.prepend_create_path "PATH", buildpath/"bin"
+    ENV["TARGETS"] = "darwin/amd64"
+    dir = buildpath/"src/k8s.io/helm"
+    dir.install buildpath.children - [buildpath/".brew_home"]
+
+    cd dir do
+      system "make", "bootstrap"
+      system "make", "build"
+
+      bin.install "bin/helm"
+      bin.install "bin/tiller"
+      man1.install Dir["docs/man/man1/*"]
+
+      output = Utils.popen_read("SHELL=bash #{bin}/helm completion bash")
+      (bash_completion/"helm").write output
+
+      output = Utils.popen_read("SHELL=zsh #{bin}/helm completion zsh")
+      (zsh_completion/"_helm").write output
+
+      prefix.install_metafiles
+    end
+  end
+
+  test do
+    system "#{bin}/helm", "create", "foo"
+    assert File.directory? "#{testpath}/foo/charts"
+
+    version_output = shell_output("#{bin}/helm version --client 2>&1")
+    assert_match "GitTreeState:\"clean\"", version_output
+    assert_match stable.instance_variable_get(:@resource).instance_variable_get(:@specs)[:revision], version_output if build.stable?
+  end
+end

--- a/Formula/kubernetes-helm@2.7.0.rb
+++ b/Formula/kubernetes-helm@2.7.0.rb
@@ -1,0 +1,49 @@
+class KubernetesHelm < Formula
+  desc "The Kubernetes package manager"
+  homepage "https://helm.sh/"
+  url "https://github.com/kubernetes/helm.git",
+      :tag => "v2.7.0",
+      :revision => "08c1144f5eb3e3b636d9775617287cc26e53dba4"
+  head "https://github.com/kubernetes/helm.git"
+
+  bottle do
+    cellar :any_skip_relocation
+    sha256 "1ecf10a071f7f2d63e885ea82ec30eababc42be3796fcd95e7f15803e947773a" => :high_sierra
+    sha256 "763a4ca21914b5388c5576869e1f3afd620f0d913174edac4923071f5080026f" => :sierra
+    sha256 "9bd7a2db55a057cbcccef388c89c9e10558f4dff8168c1b2dc3b704d227952f2" => :el_capitan
+  end
+
+  depends_on :hg => :build
+  depends_on "go" => :build
+  depends_on "glide" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+    ENV["GLIDE_HOME"] = HOMEBREW_CACHE/"glide_home/#{name}"
+    ENV.prepend_create_path "PATH", buildpath/"bin"
+    arch = MacOS.prefer_64_bit? ? "amd64" : "x86"
+    ENV["TARGETS"] = "darwin/#{arch}"
+    dir = buildpath/"src/k8s.io/helm"
+    dir.install buildpath.children - [buildpath/".brew_home"]
+
+    cd dir do
+      system "make", "bootstrap"
+      system "make", "build"
+
+      bin.install "bin/helm"
+      bin.install "bin/tiller"
+      man1.install Dir["docs/man/man1/*"]
+      bash_completion.install "scripts/completions.bash" => "helm"
+      prefix.install_metafiles
+    end
+  end
+
+  test do
+    system "#{bin}/helm", "create", "foo"
+    assert File.directory? "#{testpath}/foo/charts"
+
+    version_output = shell_output("#{bin}/helm version --client 2>&1")
+    assert_match "GitTreeState:\"clean\"", version_output
+    assert_match stable.instance_variable_get(:@resource).instance_variable_get(:@specs)[:revision], version_output if build.stable?
+  end
+end

--- a/Formula/nvm@0.34.0.rb
+++ b/Formula/nvm@0.34.0.rb
@@ -1,0 +1,45 @@
+class NvmAT0340 < Formula
+  desc "Manage multiple Node.js versions"
+  homepage "https://github.com/creationix/nvm"
+  url "https://github.com/creationix/nvm/archive/v0.34.0.tar.gz"
+  sha256 "77ad7014390e1d80fdfa663cef4ccd5cb1b697214647a4ff351e5ce3fd4c60d9"
+  head "https://github.com/creationix/nvm.git"
+
+  bottle :unneeded
+
+  def install
+    prefix.install "nvm.sh", "nvm-exec"
+    bash_completion.install "bash_completion" => "nvm"
+  end
+
+  def caveats; <<~EOS
+    Please note that upstream has asked us to make explicit managing
+    nvm via Homebrew is unsupported by them and you should check any
+    problems against the standard nvm install method prior to reporting.
+
+    You should create NVM's working directory if it doesn't exist:
+
+      mkdir ~/.nvm
+
+    Add the following to #{shell_profile} or your desired shell
+    configuration file:
+
+      export NVM_DIR="$HOME/.nvm"
+      [ -s "#{opt_prefix}/nvm.sh" ] && \. "#{opt_prefix}/nvm.sh"  # This loads nvm
+      [ -s "#{opt_prefix}/etc/bash_completion" ] && \. "#{opt_prefix}/etc/bash_completion"  # This loads nvm bash_completion
+
+    You can set $NVM_DIR to any location, but leaving it unchanged from
+    #{prefix} will destroy any nvm-installed Node installations
+    upon upgrade/reinstall.
+
+    Type `nvm help` for further information.
+  EOS
+  end
+
+  test do
+    output = pipe_output("NODE_VERSION=homebrewtest #{prefix}/nvm-exec 2>&1")
+    assert_no_match /No such file or directory/, output
+    assert_no_match /nvm: command not found/, output
+    assert_match "N/A: version \"homebrewtest -> N/A\" is not yet installed", output
+  end
+end

--- a/Formula/terraform.rb
+++ b/Formula/terraform.rb
@@ -1,18 +1,16 @@
-require "language/go"
-
 class Terraform < Formula
   desc "Tool to build, change, and version infrastructure"
   homepage "https://www.terraform.io/"
   url "https://github.com/hashicorp/terraform/archive/v0.11.10.tar.gz"
-  sha256 "f9a2730dcd68dad754cf0efa017d51929a7f333a89d07ddff3c6ff7b2d1e8be3"
+  sha256 "3cdf16618f7291ac70793f680d859223907039bdf559ca5b5e49fae7df2e736d"
   head "https://github.com/hashicorp/terraform.git"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles"
     cellar :any_skip_relocation
-    sha256 "7bce9a18c6b533bce2794ebe0876387cc1639bc4689ee5d1ec9ff38f556e0e39" => :high_sierra
-    sha256 "675d1edc6917527a0724b84ac214d7ce0b95864a2680dd404843492c1803b81c" => :sierra
-    sha256 "db14ad02da3e44831145641e57500c6f80b6be056bfb10c05dc402a93e088043" => :el_capitan
+    rebuild 1
+    sha256 "23def7afb065ed8cfed4d933f260516089603353ce87fc25f2ac87bee63a86c5" => :mojave
+    sha256 "51904d661cfe27d9dbcb0e5c04d07692f08f5524ef5a3aeee915c7b5becb30b4" => :high_sierra
+    sha256 "b6d95e097001c82821c2fdede75d122764f6cbc51a350ef526c00c35527b3cfb" => :sierra
   end
 
   depends_on "go" => :build
@@ -20,23 +18,12 @@ class Terraform < Formula
 
   conflicts_with "tfenv", :because => "tfenv symlinks terraform binaries"
 
-  # stringer is a build tool dependency
-  go_resource "golang.org/x/tools" do
-    url "https://go.googlesource.com/tools.git",
-        :branch => "release-branch.go1.10"
-  end
-
   def install
     ENV["GOPATH"] = buildpath
     ENV.prepend_create_path "PATH", buildpath/"bin"
 
     dir = buildpath/"src/github.com/hashicorp/terraform"
     dir.install buildpath.children - [buildpath/".brew_home"]
-    Language::Go.stage_deps resources, buildpath/"src"
-
-    cd "src/golang.org/x/tools/cmd/stringer" do
-      system "go", "install"
-    end
 
     cd dir do
       # v0.6.12 - source contains tests which fail if these environment variables are set locally.
@@ -46,7 +33,7 @@ class Terraform < Formula
       arch = MacOS.prefer_64_bit? ? "amd64" : "386"
       ENV["XC_OS"] = "darwin"
       ENV["XC_ARCH"] = arch
-      system "make", "test", "bin"
+      system "make", "tools", "test", "bin"
 
       bin.install "pkg/darwin_#{arch}/terraform"
       prefix.install_metafiles
@@ -59,7 +46,6 @@ class Terraform < Formula
       variable "aws_region" {
           default = "us-west-2"
       }
-
       variable "aws_amis" {
           default = {
               eu-west-1 = "ami-b1cf19c6"
@@ -68,14 +54,12 @@ class Terraform < Formula
               us-west-2 = "ami-21f78e11"
           }
       }
-
       # Specify the provider and access details
       provider "aws" {
           access_key = "this_is_a_fake_access"
           secret_key = "this_is_a_fake_secret"
           region = "${var.aws_region}"
       }
-
       resource "aws_instance" "web" {
         instance_type = "m1.small"
         ami = "${lookup(var.aws_amis, var.aws_region)}"
@@ -86,3 +70,4 @@ class Terraform < Formula
     system "#{bin}/terraform", "graph"
   end
 end
+# poking github

--- a/Formula/terraform@0.11.10.rb
+++ b/Formula/terraform@0.11.10.rb
@@ -1,0 +1,75 @@
+class TerraformAT01110 < Formula
+  desc "Tool to build, change, and version infrastructure"
+  homepage "https://www.terraform.io/"
+  url "https://github.com/hashicorp/terraform/archive/v0.11.10.tar.gz"
+  sha256 "3cdf16618f7291ac70793f680d859223907039bdf559ca5b5e49fae7df2e736d"
+  head "https://github.com/hashicorp/terraform.git"
+
+  bottle do
+    cellar :any_skip_relocation
+    rebuild 1
+    sha256 "23def7afb065ed8cfed4d933f260516089603353ce87fc25f2ac87bee63a86c5" => :mojave
+    sha256 "51904d661cfe27d9dbcb0e5c04d07692f08f5524ef5a3aeee915c7b5becb30b4" => :high_sierra
+    sha256 "b6d95e097001c82821c2fdede75d122764f6cbc51a350ef526c00c35527b3cfb" => :sierra
+  end
+
+  depends_on "go" => :build
+  depends_on "gox" => :build
+
+  conflicts_with "tfenv", :because => "tfenv symlinks terraform binaries"
+
+  def install
+    ENV["GOPATH"] = buildpath
+    ENV.prepend_create_path "PATH", buildpath/"bin"
+
+    dir = buildpath/"src/github.com/hashicorp/terraform"
+    dir.install buildpath.children - [buildpath/".brew_home"]
+
+    cd dir do
+      # v0.6.12 - source contains tests which fail if these environment variables are set locally.
+      ENV.delete "AWS_ACCESS_KEY"
+      ENV.delete "AWS_SECRET_KEY"
+
+      arch = MacOS.prefer_64_bit? ? "amd64" : "386"
+      ENV["XC_OS"] = "darwin"
+      ENV["XC_ARCH"] = arch
+      system "make", "tools", "test", "bin"
+
+      bin.install "pkg/darwin_#{arch}/terraform"
+      prefix.install_metafiles
+    end
+  end
+
+  test do
+    minimal = testpath/"minimal.tf"
+    minimal.write <<~EOS
+      variable "aws_region" {
+          default = "us-west-2"
+      }
+
+      variable "aws_amis" {
+          default = {
+              eu-west-1 = "ami-b1cf19c6"
+              us-east-1 = "ami-de7ab6b6"
+              us-west-1 = "ami-3f75767a"
+              us-west-2 = "ami-21f78e11"
+          }
+      }
+
+      # Specify the provider and access details
+      provider "aws" {
+          access_key = "this_is_a_fake_access"
+          secret_key = "this_is_a_fake_secret"
+          region = "${var.aws_region}"
+      }
+
+      resource "aws_instance" "web" {
+        instance_type = "m1.small"
+        ami = "${lookup(var.aws_amis, var.aws_region)}"
+        count = 4
+      }
+    EOS
+    system "#{bin}/terraform", "init"
+    system "#{bin}/terraform", "graph"
+  end
+end


### PR DESCRIPTION
Similar to https://github.com/ActionIQ-OSS/homebrew-taps/pull/6, this puts version-specific options for some brew formulas. These are all the brews in the mac setup script that weren't already in our private tap, plus a version downgrade of terraform.  These aren't intended to be mandatory installs, and we probably won't put them in our `Brewfile` for `brew bundle`, but with conversations like [this one](https://actioniq.slack.com/archives/CBFTD0DCN/p1547581157001300), I think we should have at least one version here preserved that works with our current Tiller installation.