### PR TITLE
Adding more osx versions for py3 install

### DIFF
--- a/Formula/python.rb
+++ b/Formula/python.rb
@@ -11,6 +11,9 @@ class Python < Formula
     sha256 "7e0fc1b078b51d9478ab08660d5df01611976a7af0f6c24054bda58264bb506c" => :high_sierra
     sha256 "2fe5ca9be0f1596798927c4aa1d4d187ca7f83adc4681483cec2cc52d7c95386" => :sierra
     sha256 "bccf50de973644608af29652f2660124d033f3213d422fe44a7f012a47643a95" => :el_capitan
+    sha256 "936bd387e48d2dea1b743eb2812d2799f40cefbb4a4c85d1c6be8657f99f8c92" => :big_sur
+    sha256 "16b18528550d8d787456711ec1ed056cc3d6d5d6be6eb34653e20df1987ba033" => :catalina
+    sha256 "7bbb9383f3ad61757e806bae4f858ac8d46b476e18e1490209daa05bcf544311" => :mojave
   end
 
   devel do

--- a/Formula/python@2.rb
+++ b/Formula/python@2.rb
@@ -10,6 +10,9 @@ class PythonAT2 < Formula
     sha256 "f557a6bed6223c3df7d5aef2941b07bfff63c159a72c167d0fa1ea17a1080230" => :high_sierra
     sha256 "53a1e22c0a2b855a363310373019796ea720f960944fc118ed7e6764fe6b206c" => :sierra
     sha256 "f0b8085f5bb129194ac9c0c6b8ba347f8add9ab35a6bad248b304985c424160e" => :el_capitan
+    sha256 "936bd387e48d2dea1b743eb2812d2799f40cefbb4a4c85d1c6be8657f99f8c92" => :big_sur
+    sha256 "16b18528550d8d787456711ec1ed056cc3d6d5d6be6eb34653e20df1987ba033" => :catalina
+    sha256 "7bbb9383f3ad61757e806bae4f858ac8d46b476e18e1490209daa05bcf544311" => :mojave
   end
 
   # Please don't add a wide/ucs4 option as it won't be accepted.


### PR DESCRIPTION
Adding more osx versions. I cant test it because I got a error like this:

```
Invalid usage: Installation of python from a GitHub commit URL is unsupported! 'brew extract python' to stable tap on GitHub instead. (UsageError)
```
So I guess I need to merge and then install it from the taps